### PR TITLE
Relax version pin for remotivelabs-broker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docutils==0.20.1
-remotivelabs-broker==0.1.10
+remotivelabs-broker~=0.1.10
 Sphinx==7.2.6
 


### PR DESCRIPTION
To allow latest version. At the moment is `0.1.19`.