### PR TITLE
feat: add cuttlefish hardware acceleration support

### DIFF
--- a/cuttlefish/Dockerfile
+++ b/cuttlefish/Dockerfile
@@ -1,15 +1,75 @@
-FROM us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration:1.28.0
+FROM ubuntu:rolling AS runner-base
+
+# Expose Operator Port (HTTP:1080, HTTPS:1443)
+EXPOSE 1080 1443
+# Expose HO(Host Orchestrator) Port (HTTP:2080, HTTPS:2443)
+EXPOSE 2080 2443
+# Expose WebRTC Port
+EXPOSE 15550-15560
+# Expose ADB Port
+# Corresponding ADB port for CF instance is, 6520+instance_num-1.
+EXPOSE 6520-6620
+# to make sure this file always exist
+RUN touch /.dockerenv
+
+USER root
+WORKDIR /root
+RUN set -x
+RUN apt update
+RUN apt install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    mesa-utils \
+    nginx \
+    less \
+    socat \
+    unzip \
+    netcat-traditional \
+    sudo \
+    mesa-vulkan-drivers \
+    mesa-utils-extra \
+    vulkan-tools
+RUN update-ca-certificates
+
+FROM runner-base AS runner-prod
+
+# android-cuttlefish
+# android-cuttlefish-unstable
+# android-cuttlefish-nightly
+ARG REPO=android-cuttlefish
+RUN apt install -y --no-install-recommends gnupg
+RUN install -d -m 0755 /etc/apt/keyrings
+RUN curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/android-cuttlefish-archive-keyring.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/android-cuttlefish-archive-keyring.gpg] https://us-apt.pkg.dev/projects/android-cuttlefish-artifacts $REPO main" \
+    | tee -a /etc/apt/sources.list.d/artifact-registry.list
+RUN apt update
+RUN apt install -y --no-install-recommends \
+    cuttlefish-base \
+    cuttlefish-user \
+    cuttlefish-orchestration
+
+
+FROM runner-prod AS runner
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-  apt-get install -y less socat unzip netcat-traditional && \
-  rm -rf /var/lib/apt/lists/*
+ENV EGL_PLATFORM=surfaceless
 
 WORKDIR /root
 ADD ${TARGETARCH}/cvd-host_package.tar.gz .
 RUN --mount=type=bind,source=./${TARGETARCH}/,target=/tmp/${TARGETARCH}/,readonly \
   unzip /tmp/${TARGETARCH}/aosp_trout_*-img.zip
 COPY init.sh .
+
+# TODO(b/491256959): Seek better option than introducing wrapper of bsdtar.
+# Add bsdtar wrapper, to avoid owner user/group issue when fetching artifacts.
+RUN dpkg-divert --add --rename --divert /usr/bin/bsdtar.real /usr/bin/bsdtar && \
+    echo '#!/bin/bash' > /usr/bin/bsdtar && \
+    echo '/usr/bin/bsdtar.real --no-same-owner "$@"' >> /usr/bin/bsdtar && \
+    chmod +x /usr/bin/bsdtar
+
+RUN usermod -aG kvm root
+RUN usermod -aG cvdnetwork root
 
 ENTRYPOINT [ "/root/init.sh" ]

--- a/cuttlefish/init.sh
+++ b/cuttlefish/init.sh
@@ -3,7 +3,10 @@
 ulimit -n 4096
 
 # Existing orchestrator startup script
-./run_services.sh &
+service nginx start
+service cuttlefish-host-resources start
+service cuttlefish-operator start
+service cuttlefish-host_orchestrator start
 
 # Wait for orchestrator to start
 until nc -z localhost 2081 2>/dev/null; do sleep 1; done
@@ -19,11 +22,12 @@ cp -n *.img state/images
   --vhost_user_vsock=false \
   --instance_dir=/root/state/ \
   --system_image_dir=/root/state/images \
+  --gpu_mode=${CUTTLEFISH_GPU_MODE:-auto} \
   --memory_mb=${CUTTLEFISH_MEMORY_MB:-4096} \
   --guest_enforce_security=false \
   --enable_vhal_proxy_server \
-  --display=width=1400,height=800,dpi=160,refresh_rate_hz=30 \
-  --display=width=600,height=800,dpi=160,refresh_rate_hz=30 \
+  --display=${CUTTLEFISH_DISPLAY_MAIN:-width=1400,height=800,dpi=160,refresh_rate_hz=30} \
+  --display=${CUTTLEFISH_DISPLAY_CLUSTER:-width=600,height=800,dpi=160,refresh_rate_hz=30} \
   --report_anonymous_usage_stats=n
 sleep 3
 


### PR DESCRIPTION

  - Add hardware acceleration support via `CUTTLEFISH_HW_ACC` env var
  - Add env var configuration for displays (`CUTTLEFISH_DISPLAY_MAIN`, `CUTTLEFISH_DISPLAY_CLUSTER`)
  - NOTE: No need to pass `/dev/dri` since we run `--privileged`
  - NVIDIA should be supported out of the box with `--gpus all` on the docker run cmd and `CUTTLEFISH_HW_ACC=true`